### PR TITLE
Standardize Docker Hub secrets across all workflows

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -162,7 +162,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Extract metadata
         id: meta

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -125,7 +125,7 @@ jobs:
     - name: Check Docker Hub credentials
       id: check-credentials
       run: |
-        if [ -z "${{ secrets.DOCKERHUB_USERNAME }}" ] || [ -z "${{ secrets.DOCKERHUB_TOKEN }}" ]; then
+        if [ -z "${{ secrets.DOCKER_USERNAME }}" ] || [ -z "${{ secrets.DOCKER_TOKEN }}" ]; then
           echo "skip=true" >> $GITHUB_OUTPUT
           echo "⚠️ Docker Hub credentials not configured - skipping Docker Hub publish"
         else
@@ -137,15 +137,15 @@ jobs:
       if: steps.check-credentials.outputs.skip != 'true'
       uses: docker/login-action@v3
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_TOKEN }}
 
     - name: Extract metadata for Docker Hub
       if: steps.check-credentials.outputs.skip != 'true'
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: ${{ secrets.DOCKERHUB_USERNAME }}/star-daemon
+        images: ${{ secrets.DOCKER_USERNAME }}/star-daemon
         tags: |
           type=ref,event=branch
           type=semver,pattern={{version}}


### PR DESCRIPTION
- Change DOCKERHUB_USERNAME/DOCKERHUB_TOKEN to DOCKER_USERNAME/DOCKER_TOKEN
- Both ci-cd.yml and docker-build-publish.yml now use same secret names
- Matches existing GitHub Actions secrets configuration