### PR TITLE
chore: consolidate dependency updates

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -40,7 +40,7 @@ jobs:
     needs: lint
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -107,7 +107,7 @@ jobs:
   #   needs: test
   #   steps:
   #     - name: Checkout code
-  #       uses: actions/checkout@v5
+  #       uses: actions/checkout@v6
   #
   #     - name: Run Snyk to check for vulnerabilities
   #       uses: snyk/actions/python@master
@@ -127,7 +127,7 @@ jobs:
     needs: test
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -157,7 +157,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Dependency Review
         uses: actions/dependency-review-action@v4

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -29,7 +29,7 @@ jobs:
           pip-compile requirements.in --upgrade -o requirements-new.txt
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'chore: update dependencies'

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -25,7 +25,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     
     - name: Set lowercase image name
       id: image-name
@@ -117,7 +117,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ certifi==2025.10.5
 urllib3==2.5.0
 charset-normalizer==3.4.4
 idna==3.11
-protobuf==6.33.0
+protobuf==6.33.5
 
 # Async support for Matrix
 aiohttp==3.13.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ aiofiles==25.1.0
 # Secrets Management (Optional - install what you need)
 doppler-sdk==1.3.0  # Doppler
 boto3==1.40.60  # AWS Secrets Manager
-hvac==2.3.0  # HashiCorp Vault
+hvac==2.4.0  # HashiCorp Vault
 
 # Dependencies
 python-dateutil==2.9.0.post0

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ discord-webhook==1.4.1
 # matrix-nio removed - using Matrix Client-Server API directly via requests
 
 # Security and utilities
-certifi==2025.10.5
+certifi==2026.1.4
 urllib3==2.5.0
 charset-normalizer==3.4.4
 idna==3.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ idna==3.11
 protobuf==6.33.0
 
 # Async support for Matrix
-aiohttp==3.13.1
+aiohttp==3.13.3
 aiofiles==25.1.0
 
 # Secrets Management (Optional - install what you need)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ Mastodon.py==2.1.4
 
 # BlueSky / AT Protocol
 atproto==0.0.63
-beautifulsoup4==4.14.2
+beautifulsoup4==4.14.3
 
 # Discord
 discord.py==2.6.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ discord-webhook==1.4.1
 
 # Security and utilities
 certifi==2025.10.5
-urllib3==2.5.0
+urllib3==2.6.3
 charset-normalizer==3.4.4
 idna==3.11
 protobuf==6.33.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ PyGithub==2.8.1
 Mastodon.py==2.1.4
 
 # BlueSky / AT Protocol
-atproto==0.0.63
+atproto==0.0.65
 beautifulsoup4==4.14.2
 
 # Discord

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ aiofiles==25.1.0
 
 # Secrets Management (Optional - install what you need)
 doppler-sdk==1.3.0  # Doppler
-boto3==1.40.60  # AWS Secrets Manager
+boto3==1.42.39  # AWS Secrets Manager
 hvac==2.3.0  # HashiCorp Vault
 
 # Dependencies


### PR DESCRIPTION
Consolidates all 10 dependabot dependency updates into a single PR:

**GitHub Actions:**
- Bump actions/checkout from 5 to 6
- Bump peter-evans/create-pull-request from 7 to 8

**Python packages:**
- Bump aiohttp to 3.13.3
- Bump atproto to 0.0.65
- Bump beautifulsoup4 to 4.14.3
- Bump boto3 to 1.42.39
- Bump certifi to 2026.1.4 (security)
- Bump hvac to 2.4.0
- Bump protobuf to 6.33.5
- Bump urllib3 to 2.6.3 (security)